### PR TITLE
Add CI and an emulator-free PRG↔TAP↔WAV round-trip test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run tests
+        run: pytest -v

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # wav2tapsp
 wav2tapsp
 
-Converts WAV files to C64 TAP files.
+[![CI](https://github.com/anarkiwi/wav2tapsp/actions/workflows/ci.yml/badge.svg)](https://github.com/anarkiwi/wav2tapsp/actions/workflows/ci.yml)
+
+Converts WAV files (recordings of C64 cassette tapes) to C64 TAP files an emulator can read.
 
 Hardly unique, but also somewhat easier to experiment with than having to hack ancient C code...
 
@@ -11,3 +13,27 @@ $ ./wav2tapsp.py
 usage: wav2tapsp.py [-h] [--cpufreq CPUFREQ] wavfile
 wav2tapsp.py: error: the following arguments are required: wavfile
 ```
+
+## Testing
+
+Tests run automatically in CI (GitHub Actions) across Python 3.10 - 3.13. To run
+them yourself:
+
+```
+$ pip3 install -r requirements-dev.txt
+$ pytest -v
+```
+
+The headline test is a full, emulator-free round trip that proves `wav2tapsp`
+preserves tape timing well enough to recover the original program:
+
+```
+PRG  ->  TAP  ->  WAV  --(wav2tapsp)-->  TAP  ->  PRG
+```
+
+It generates a real C64 BASIC program, encodes it as a C64 ROM-format `.tap`
+(leader / countdown sync / per-byte dipole markers / odd parity / per-block
+checksum, two block copies), synthesises a `.wav` of the tape audio, runs it back
+through `wav2tapsp`, decodes the resulting `.tap`, and asserts the recovered PRG
+is byte-identical to the original *and* still a structurally valid, runnable
+BASIC program. The C64 tape format helpers live in [`c64tape.py`](c64tape.py).

--- a/c64tape.py
+++ b/c64tape.py
@@ -1,0 +1,376 @@
+#!/usr/bin/python
+
+# Copyright 2022 Josh Bailey (josh@vandervecken.com)
+
+"""Self-contained Commodore 64 cassette-tape toolkit.
+
+Implements just enough of the C64 ROM ("Kernal") tape format to drive a full
+round-trip test of ``wav2tapsp`` with no emulator or copyrighted ROMs:
+
+    PRG  ->  TAP  ->  WAV  --(wav2tapsp)-->  TAP  ->  PRG
+
+The format implemented here (leader / countdown sync / per-byte dipole markers /
+odd parity / per-block checksum / two block copies) is the standard format the
+C64 ROM SAVEs and LOADs, so the produced .tap files are real C64 tapes.
+
+References:
+  http://unusedino.de/ec64/technical/formats/tap.html
+  https://web.archive.org/web/20180709173001/http://c64tapes.org/dokuwiki/doku.php?id=analyzing_loaders
+"""
+
+import struct
+import wave
+
+import numpy as np
+
+# PAL CPU frequency in Hz (matches wav2tapsp's default).
+CPU_FREQ = 985248
+
+# Standard ROM-loader pulse lengths, in TAP units (CPU cycles / 8).
+SHORT = 0x30    # 48
+MEDIUM = 0x42   # 66
+LONG = 0x56     # 86
+
+# Decode thresholds: midpoints between the nominal pulse lengths. A recovered
+# pulse below _SM is "short", below _ML is "medium", otherwise "long".
+_SM = (SHORT + MEDIUM) // 2     # 57
+_ML = (MEDIUM + LONG) // 2      # 76
+
+TAP_MAGIC = b'C64-TAPE-RAW'
+
+# C64 BASIC starts at $0801.
+BASIC_START = 0x0801
+
+# A handful of BASIC V2 tokens (enough for the sample program).
+TOK_GOTO = 0x89
+TOK_PRINT = 0x99
+
+# Countdown "sync" bytes written before each block. The high bit distinguishes
+# the first copy of a block (0x89..0x81) from the repeated copy (0x09..0x01).
+_SYNC_FIRST = [0x89, 0x88, 0x87, 0x86, 0x85, 0x84, 0x83, 0x82, 0x81]
+_SYNC_REPEAT = [0x09, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]
+
+# Tape header (cassette buffer) is always 192 bytes.
+HEADER_SIZE = 192
+
+
+class DecodeError(Exception):
+    """Raised when a pulse stream cannot be decoded as a C64 tape."""
+
+
+# --------------------------------------------------------------------------
+# BASIC PRG generation / validation
+# --------------------------------------------------------------------------
+
+def make_basic_prg(lines):
+    """Build a tokenised C64 BASIC .prg from ``[(line_number, token_bytes), ...]``.
+
+    Returns the full PRG image: 2-byte little-endian load address followed by
+    the linked list of BASIC lines and a terminating null link.
+    """
+    body = bytearray()
+    addr = BASIC_START
+    for line_no, tokens in lines:
+        tokens = bytes(tokens)
+        # line = link(2) + line number(2) + tokens + end-of-line(0x00)
+        line_len = 2 + 2 + len(tokens) + 1
+        next_addr = addr + line_len
+        body += struct.pack('<H', next_addr)
+        body += struct.pack('<H', line_no)
+        body += tokens
+        body += b'\x00'
+        addr = next_addr
+    # null link terminates the program
+    body += b'\x00\x00'
+    return struct.pack('<H', BASIC_START) + bytes(body)
+
+
+def sample_basic_prg():
+    """A small but genuine, runnable C64 BASIC program."""
+    line10 = bytes([TOK_PRINT]) + b'"HELLO, WORLD!"'
+    line20 = bytes([TOK_GOTO]) + b' 10'
+    return make_basic_prg([(10, line10), (20, line20)])
+
+
+def parse_basic_prg(prg):
+    """Walk a tokenised BASIC PRG, returning ``[(line_number, token_bytes), ...]``.
+
+    Validates the line-link structure (each line's link must point at the next
+    line, the program must end with a null link). Raises ``ValueError`` if the
+    bytes are not a structurally valid BASIC program.
+    """
+    if len(prg) < 2:
+        raise ValueError('PRG too short')
+    load = prg[0] | (prg[1] << 8)
+    mem = prg[2:]
+    lines = []
+    pos = 0
+    addr = load
+    while True:
+        if pos + 2 > len(mem):
+            raise ValueError('truncated link pointer')
+        link = mem[pos] | (mem[pos + 1] << 8)
+        if link == 0:
+            break
+        if pos + 4 > len(mem):
+            raise ValueError('truncated line header')
+        line_no = mem[pos + 2] | (mem[pos + 3] << 8)
+        k = pos + 4
+        while k < len(mem) and mem[k] != 0:
+            k += 1
+        if k >= len(mem):
+            raise ValueError('unterminated BASIC line')
+        tokens = bytes(mem[pos + 4:k])
+        expected_link = addr + (k + 1 - pos)
+        if link != expected_link:
+            raise ValueError('bad line link: got $%04x want $%04x' % (link, expected_link))
+        lines.append((line_no, tokens))
+        addr = link
+        pos = k + 1
+    return lines
+
+
+# --------------------------------------------------------------------------
+# PRG -> TAP (encode)
+# --------------------------------------------------------------------------
+
+def _emit_bit(pulses, bit):
+    # 0 = short,medium ; 1 = medium,short
+    if bit:
+        pulses.append(MEDIUM)
+        pulses.append(SHORT)
+    else:
+        pulses.append(SHORT)
+        pulses.append(MEDIUM)
+
+
+def _emit_byte(pulses, value):
+    # byte marker dipole: long,medium
+    pulses.append(LONG)
+    pulses.append(MEDIUM)
+    parity = 1
+    for i in range(8):
+        bit = (value >> i) & 1   # LSB first
+        _emit_bit(pulses, bit)
+        parity ^= bit
+    _emit_bit(pulses, parity)    # odd parity check bit
+
+
+def _emit_block(pulses, payload, first_copy, leader):
+    pulses.extend([SHORT] * leader)
+    sync = _SYNC_FIRST if first_copy else _SYNC_REPEAT
+    checksum = 0
+    for b in payload:
+        checksum ^= b
+    for b in sync:
+        _emit_byte(pulses, b)
+    for b in payload:
+        _emit_byte(pulses, b)
+    _emit_byte(pulses, checksum)
+
+
+def _make_header(file_type, start, end, name):
+    buf = bytearray([0x20] * HEADER_SIZE)
+    buf[0] = file_type
+    buf[1] = start & 0xff
+    buf[2] = (start >> 8) & 0xff
+    buf[3] = end & 0xff
+    buf[4] = (end >> 8) & 0xff
+    nm = name.encode('ascii')[:16]
+    buf[5:5 + len(nm)] = nm
+    return bytes(buf)
+
+
+def prg_to_tap(prg, name='WAV2TAPSP', file_type=1, copies=2,
+               first_leader=1500, mid_leader=400, trailer=400):
+    """Encode a PRG as a C64 ROM-format .tap file (returns bytes).
+
+    A header block (load/end address + name) and the program data block are each
+    written ``copies`` times, exactly as the C64 ROM SAVE routine does.
+    """
+    if len(prg) < 2:
+        raise ValueError('PRG too short')
+    start = prg[0] | (prg[1] << 8)
+    data = prg[2:]
+    end = start + len(data)
+    header = _make_header(file_type, start, end, name)
+
+    pulses = []
+    for copy in range(copies):
+        leader = first_leader if copy == 0 else mid_leader
+        _emit_block(pulses, header, first_copy=(copy == 0), leader=leader)
+    for copy in range(copies):
+        _emit_block(pulses, data, first_copy=(copy == 0), leader=mid_leader)
+    pulses.extend([SHORT] * trailer)
+
+    return _wrap_tap(pulses)
+
+
+def _wrap_tap(pulses):
+    body = bytes(pulses)
+    out = bytearray()
+    out += TAP_MAGIC
+    out += bytes([0])           # version 0
+    out += bytes(3)             # reserved
+    out += struct.pack('<I', len(body))
+    out += body
+    return bytes(out)
+
+
+def parse_tap(tap_bytes):
+    """Read a version-0 .tap container, returning the list of pulse bytes."""
+    if tap_bytes[:12] != TAP_MAGIC:
+        raise DecodeError('not a C64 TAP file')
+    (length,) = struct.unpack('<I', tap_bytes[16:20])
+    return list(tap_bytes[20:20 + length])
+
+
+# --------------------------------------------------------------------------
+# TAP -> WAV (synthesise audio)
+# --------------------------------------------------------------------------
+
+def tap_pulses_to_samples(pulses, samplerate, cpufreq=CPU_FREQ, amplitude=20000):
+    """Render TAP pulses as a square-wave int16 sample array.
+
+    Each pulse becomes one full wave cycle (high half then low half) whose period
+    is ``pulse * 8 / cpufreq`` seconds, so every pulse boundary is a single rising
+    zero crossing -- exactly what wav2tapsp measures.
+    """
+    p = np.asarray(pulses, dtype=np.float64)
+    dur_n = p * 8.0 / cpufreq * samplerate     # samples per pulse (float)
+    starts = np.empty(len(p) + 1)
+    starts[0] = 0.0
+    np.cumsum(dur_n, out=starts[1:])
+    total = int(np.ceil(starts[-1]))
+    n = np.arange(total)
+    idx = np.searchsorted(starts, n, side='right') - 1
+    np.clip(idx, 0, len(p) - 1, out=idx)
+    within = n - starts[idx]
+    high = within < (dur_n[idx] * 0.5)
+    return np.where(high, amplitude, -amplitude).astype(np.int16)
+
+
+def write_wav(path, samples, samplerate):
+    """Write a mono 16-bit PCM WAV file (readable by scipy.io.wavfile)."""
+    with wave.open(path, 'wb') as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(samplerate)
+        w.writeframes(np.asarray(samples, dtype='<i2').tobytes())
+
+
+# --------------------------------------------------------------------------
+# TAP -> PRG (decode)
+# --------------------------------------------------------------------------
+
+def _classify(pulses):
+    out = []
+    for v in pulses:
+        if v <= 0 or v >= 256:
+            out.append('X')      # dropped / overflow / gap
+        elif v < _SM:
+            out.append('S')
+        elif v < _ML:
+            out.append('M')
+        else:
+            out.append('L')
+    return out
+
+
+def _next_marker(syms, i):
+    while i < len(syms) and syms[i] != 'L':
+        i += 1
+    return i
+
+
+def _read_bit(syms, j):
+    a, b = syms[j], syms[j + 1]
+    if a == 'S' and b == 'M':
+        return 0
+    if a == 'M' and b == 'S':
+        return 1
+    raise DecodeError('bad bit dipole %s%s at %d' % (a, b, j))
+
+
+def _read_byte(syms, i):
+    if not (i + 20 <= len(syms) and syms[i] == 'L' and syms[i + 1] == 'M'):
+        raise DecodeError('expected byte marker at %d' % i)
+    value = 0
+    parity = 1
+    j = i + 2
+    for b in range(8):
+        bit = _read_bit(syms, j)
+        value |= bit << b
+        parity ^= bit
+        j += 2
+    if _read_bit(syms, j) != parity:
+        raise DecodeError('parity error in byte at %d' % i)
+    return value, i + 20
+
+
+def _read_block(syms, i):
+    """Read consecutive bytes (no leader between them) starting at a marker."""
+    out = []
+    while i + 20 <= len(syms) and syms[i] == 'L' and syms[i + 1] == 'M':
+        value, i = _read_byte(syms, i)
+        out.append(value)
+    return out, i
+
+
+def _strip_block(block):
+    """Split a decoded block into its payload, validating the checksum.
+
+    Layout: 9 countdown sync bytes, then the payload, then a 1-byte XOR checksum.
+    """
+    if len(block) < 10:
+        raise DecodeError('block too short: %d bytes' % len(block))
+    payload = block[9:-1]
+    checksum = block[-1]
+    calc = 0
+    for b in payload:
+        calc ^= b
+    if calc != checksum:
+        raise DecodeError('checksum mismatch: got %d want %d' % (calc, checksum))
+    return payload
+
+
+def pulses_to_prg(pulses):
+    """Decode a list of TAP pulse bytes back into a PRG image."""
+    syms = _classify(pulses)
+    blocks = []
+    i = 0
+    while True:
+        i = _next_marker(syms, i)
+        if i >= len(syms):
+            break
+        block, i = _read_block(syms, i)
+        if block:
+            blocks.append(block)
+
+    if len(blocks) < 2:
+        raise DecodeError('expected at least a header and a data block, got %d' % len(blocks))
+
+    header = _strip_block(blocks[0])
+    if len(header) != HEADER_SIZE:
+        raise DecodeError('header block is %d bytes, expected %d' % (len(header), HEADER_SIZE))
+    start = header[1] | (header[2] << 8)
+    end = header[3] | (header[4] << 8)
+    data_len = end - start
+
+    data = None
+    for blk in blocks[1:]:
+        payload = _strip_block(blk)
+        if payload == header:
+            continue            # a repeated copy of the header
+        if len(payload) == data_len:
+            data = payload
+            break
+    if data is None:
+        raise DecodeError('no data block of length %d found' % data_len)
+
+    return struct.pack('<H', start) + bytes(data)
+
+
+def tap_to_prg(tap_bytes):
+    """Decode a .tap file (bytes) back into a PRG image."""
+    return pulses_to_prg(parse_tap(tap_bytes))

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the repo-root modules (wav2tapsp, c64tape) importable from tests/.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,92 @@
+"""Unit tests for the C64 tape toolkit (no audio involved)."""
+
+import struct
+
+import numpy as np
+import pytest
+
+import c64tape
+
+
+def test_sample_prg_is_valid_basic():
+    prg = c64tape.sample_basic_prg()
+    # load address is BASIC start ($0801)
+    assert prg[:2] == struct.pack('<H', c64tape.BASIC_START)
+    lines = c64tape.parse_basic_prg(prg)
+    assert [ln for ln, _ in lines] == [10, 20]
+    # line 10 is PRINT "HELLO, WORLD!"
+    assert lines[0][1] == bytes([c64tape.TOK_PRINT]) + b'"HELLO, WORLD!"'
+
+
+def test_parse_basic_prg_rejects_bad_link():
+    prg = bytearray(c64tape.sample_basic_prg())
+    prg[2] ^= 0xff  # corrupt the first line's link pointer
+    with pytest.raises(ValueError):
+        c64tape.parse_basic_prg(bytes(prg))
+
+
+def test_tap_container_roundtrip():
+    prg = c64tape.sample_basic_prg()
+    tap = c64tape.prg_to_tap(prg)
+    assert tap[:12] == c64tape.TAP_MAGIC
+    pulses = c64tape.parse_tap(tap)
+    # every pulse is a legal single-byte length
+    assert pulses
+    assert all(0 < p < 256 for p in pulses)
+    # only short/medium/long lengths are emitted
+    assert set(pulses) <= {c64tape.SHORT, c64tape.MEDIUM, c64tape.LONG}
+
+
+def test_encode_then_decode_without_audio():
+    # The encoder and decoder are self-consistent end to end.
+    prg = c64tape.sample_basic_prg()
+    tap = c64tape.prg_to_tap(prg)
+    assert c64tape.tap_to_prg(tap) == prg
+
+
+def test_decode_recovers_header_addresses():
+    prg = c64tape.sample_basic_prg()
+    tap = c64tape.prg_to_tap(prg)
+    pulses = c64tape.parse_tap(tap)
+    blocks = []
+    syms = c64tape._classify(pulses)
+    i = 0
+    while True:
+        i = c64tape._next_marker(syms, i)
+        if i >= len(syms):
+            break
+        block, i = c64tape._read_block(syms, i)
+        if block:
+            blocks.append(block)
+    # two header copies + two data copies
+    assert len(blocks) == 4
+    header = c64tape._strip_block(blocks[0])
+    start = header[1] | (header[2] << 8)
+    end = header[3] | (header[4] << 8)
+    assert start == c64tape.BASIC_START
+    assert end == c64tape.BASIC_START + (len(prg) - 2)
+
+
+def test_corrupt_pulse_is_detected():
+    prg = c64tape.sample_basic_prg()
+    pulses = c64tape.parse_tap(c64tape.prg_to_tap(prg))
+    # flip a data pulse in the middle of the stream into the wrong class
+    mid = len(pulses) // 2
+    pulses[mid] = c64tape.LONG if pulses[mid] != c64tape.LONG else c64tape.SHORT
+    with pytest.raises(c64tape.DecodeError):
+        c64tape.pulses_to_prg(pulses)
+
+
+def test_arbitrary_prg_roundtrips_without_audio():
+    # Not a BASIC program -- arbitrary bytes with a load address still survive.
+    prg = struct.pack('<H', 0xC000) + bytes(range(200))
+    tap = c64tape.prg_to_tap(prg, file_type=3)
+    assert c64tape.tap_to_prg(tap) == prg
+
+
+def test_tap_pulses_to_samples_shape():
+    pulses = [c64tape.SHORT, c64tape.MEDIUM, c64tape.LONG] * 10
+    samples = c64tape.tap_pulses_to_samples(pulses, 48000)
+    assert samples.dtype == np.int16
+    # only +/- amplitude values are produced (clean square wave)
+    assert set(np.unique(samples).tolist()) <= {-20000, 20000}

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -1,0 +1,85 @@
+"""Full round-trip tests that exercise wav2tapsp on synthesised audio.
+
+    PRG  ->  TAP  ->  WAV  --(wav2tapsp)-->  TAP  ->  PRG
+
+The recovered PRG must be byte-identical to the original and must still be a
+structurally valid, runnable C64 BASIC program.
+"""
+
+import os
+import subprocess
+import sys
+
+import numpy as np
+
+import c64tape
+import wav2tapsp
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# 96 kHz gives a comfortable timing margin for the short/medium/long pulse
+# classification after the lossy WAV -> TAP re-quantisation.
+SAMPLERATE = 96000
+
+
+def _make_wav_for(prg, path):
+    pulses = c64tape.parse_tap(c64tape.prg_to_tap(prg))
+    samples = c64tape.tap_pulses_to_samples(pulses, SAMPLERATE)
+    c64tape.write_wav(path, samples, SAMPLERATE)
+
+
+def test_roundtrip_in_process():
+    prg = c64tape.sample_basic_prg()
+    expected_lines = c64tape.parse_basic_prg(prg)
+
+    # PRG -> TAP -> WAV samples
+    pulses = c64tape.parse_tap(c64tape.prg_to_tap(prg))
+    samples = c64tape.tap_pulses_to_samples(pulses, SAMPLERATE)
+
+    # WAV -> TAP via the code under test
+    tap = wav2tapsp.wav_to_tap(samples, SAMPLERATE)
+
+    # TAP -> PRG (the "final C64 program")
+    recovered = c64tape.tap_to_prg(tap)
+
+    assert recovered == prg
+    assert c64tape.parse_basic_prg(recovered) == expected_lines
+
+
+def test_roundtrip_via_cli(tmp_path):
+    prg = c64tape.sample_basic_prg()
+    wav_path = str(tmp_path / 'roundtrip.wav')
+    _make_wav_for(prg, wav_path)
+
+    # Run the actual command-line entry point, exactly as a user would.
+    subprocess.run(
+        [sys.executable, os.path.join(ROOT, 'wav2tapsp.py'), wav_path],
+        check=True, cwd=ROOT)
+
+    tap_path = wav_path[:-4] + '.tap'
+    assert os.path.exists(tap_path)
+    with open(tap_path, 'rb') as f:
+        tap = f.read()
+
+    recovered = c64tape.tap_to_prg(tap)
+    assert recovered == prg
+    assert c64tape.parse_basic_prg(recovered) == c64tape.parse_basic_prg(prg)
+
+
+def test_roundtrip_arbitrary_payload():
+    # A non-BASIC payload (machine-code-like bytes) round-trips through audio too.
+    import struct
+    prg = struct.pack('<H', 0xC000) + bytes((i * 37 + 11) & 0xff for i in range(160))
+    pulses = c64tape.parse_tap(c64tape.prg_to_tap(prg, file_type=3))
+    samples = c64tape.tap_pulses_to_samples(pulses, SAMPLERATE)
+    tap = wav2tapsp.wav_to_tap(samples, SAMPLERATE)
+    assert c64tape.tap_to_prg(tap) == prg
+
+
+def test_constant_pulse_recovered():
+    # wav2tapsp should recover a constant-pulse tone to (about) that pulse length.
+    for nominal in (c64tape.SHORT, c64tape.MEDIUM, c64tape.LONG):
+        samples = c64tape.tap_pulses_to_samples([nominal] * 300, SAMPLERATE)
+        recovered = wav2tapsp.wav_to_pulses(samples, SAMPLERATE)
+        steady = recovered[5:-5]
+        assert abs(float(np.median(steady)) - nominal) <= 1

--- a/wav2tapsp.py
+++ b/wav2tapsp.py
@@ -13,49 +13,80 @@ import pandas as pd
 import numpy as np
 import scipy.io.wavfile
 
-parser = argparse.ArgumentParser(description='Convert WAV file into a C64 .tap file')
-parser.add_argument('wavfile', help='input WAV file')
-parser.add_argument('--cpufreq', default=int(985248), help='CPU frequency in Hz')
-args = parser.parse_args()
+# PAL CPU frequency in Hz.
+DEFAULT_CPUFREQ = 985248
 
-# TODO: could add audio/gain processing here.
-sr, x = scipy.io.wavfile.read(args.wavfile)
-if len(x.shape) == 1:
-    df = pd.DataFrame(x, columns=['s'], dtype=pd.Float32Dtype())
-else:
-    # if stereo, mean of channel samples
-    df = pd.DataFrame(np.column_stack(np.transpose(x)), columns=['x', 'y'], dtype=pd.Float32Dtype())
-    df['s'] = df.mean(axis=1)
 
-# calculate timestamps
-df['t'] = df.index / sr * 1e6
-df['t'] = df['t'].astype(np.uint64)
+def wav_to_pulses(x, sr, cpufreq=DEFAULT_CPUFREQ):
+    """Convert PCM samples (as read by scipy.io.wavfile) into TAP pulse bytes.
 
-# calculate zero crossings, between samples
-df['ls'] = df['s'].shift(1).fillna(0)
-df.loc[(df.ls == df.s), ['ls', 's']] = pd.NA
-df['zo'] = df.ls / (df.ls - df.s)
-df.loc[~((df.ls < 0) & (df.s >= 0)), ['zo']] = pd.NA
-df['lastzo'] = df['zo'].shift().fillna(method='ffill')
-df['zt'] = df['t'] + df['zo'] - df['lastzo']
+    Returns a uint8 numpy array of TAP pulse lengths (CPU cycles / 8), one per
+    rising zero crossing in the signal.
+    """
+    # TODO: could add audio/gain processing here.
+    if len(x.shape) == 1:
+        df = pd.DataFrame(x, columns=['s'], dtype=pd.Float32Dtype())
+    else:
+        # if stereo, mean of channel samples
+        df = pd.DataFrame(np.column_stack(np.transpose(x)), columns=['x', 'y'], dtype=pd.Float32Dtype())
+        df['s'] = df.mean(axis=1)
 
-# select zero crossings
-df = df[df['zt'].notna()]
-# calculate pulse length bytes
-df['pl'] = df.zt.diff().fillna(0) * ((1e-6 * args.cpufreq) / 8)
-# remove overflows
-df.loc[df['pl'] > 255, ['pl']] = 0
-df['pl'] = df.pl.fillna(0).astype(np.uint8)
+    # calculate timestamps
+    df['t'] = df.index / sr * 1e6
+    df['t'] = df['t'].astype(np.uint64)
 
-outfile = args.wavfile.replace('.wav', '.tap')
-assert args.wavfile != outfile
+    # calculate zero crossings, between samples
+    df['ls'] = df['s'].shift(1).fillna(0)
+    df.loc[(df.ls == df.s), ['ls', 's']] = pd.NA
+    df['zo'] = df.ls / (df.ls - df.s)
+    df.loc[~((df.ls < 0) & (df.s >= 0)), ['zo']] = pd.NA
+    df['lastzo'] = df['zo'].shift().ffill()
+    df['zt'] = df['t'] + df['zo'] - df['lastzo']
 
-with open(outfile, 'wb') as f:
-    f.write(bytes('C64-TAPE-RAW', 'utf8'))
+    # select zero crossings
+    df = df[df['zt'].notna()]
+    # calculate pulse length bytes
+    df['pl'] = df.zt.diff().fillna(0) * ((1e-6 * cpufreq) / 8)
+    # remove overflows
+    df.loc[df['pl'] > 255, ['pl']] = 0
+    df['pl'] = df.pl.fillna(0).astype(np.uint8)
+    return df['pl'].to_numpy()
+
+
+def pulses_to_tap(pulses):
+    """Wrap an array of TAP pulse bytes in a C64-TAPE-RAW (version 0) container."""
+    out = bytearray()
+    out += bytes('C64-TAPE-RAW', 'utf8')
     # version 0, no long pulse handling
-    f.write(struct.pack('b', 0))
+    out += struct.pack('b', 0)
     # reserved
-    f.write(bytes(3))
+    out += bytes(3)
     # payload
-    f.write(struct.pack('I', len(df.pl)))
-    f.write(df.pl.to_numpy().tobytes())
+    out += struct.pack('I', len(pulses))
+    out += pulses.tobytes()
+    return bytes(out)
+
+
+def wav_to_tap(x, sr, cpufreq=DEFAULT_CPUFREQ):
+    """Convert PCM samples into a complete .tap file as bytes."""
+    return pulses_to_tap(wav_to_pulses(x, sr, cpufreq))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description='Convert WAV file into a C64 .tap file')
+    parser.add_argument('wavfile', help='input WAV file')
+    parser.add_argument('--cpufreq', default=int(DEFAULT_CPUFREQ), type=int, help='CPU frequency in Hz')
+    args = parser.parse_args(argv)
+
+    sr, x = scipy.io.wavfile.read(args.wavfile)
+    tap = wav_to_tap(x, sr, args.cpufreq)
+
+    outfile = args.wavfile.replace('.wav', '.tap')
+    assert args.wavfile != outfile
+
+    with open(outfile, 'wb') as f:
+        f.write(tap)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What

Adds GitHub Actions CI and a self-contained **round-trip test** that exercises `wav2tapsp` end to end, entirely in CI — no emulator or copyrighted C64 ROMs required.

```
PRG  ->  TAP  ->  WAV  --(wav2tapsp)-->  TAP  ->  PRG
```

The test:
1. Generates a real, runnable C64 BASIC program (`10 PRINT "HELLO, WORLD!" : 20 GOTO 10`).
2. Encodes it as a C64 ROM-format `.tap` (leader / countdown sync / per-byte dipole markers / odd parity / per-block checksum, two block copies).
3. Synthesises a `.wav` of the tape audio (square wave, one cycle per pulse).
4. Runs it back through **`wav2tapsp`** (the code under test) to get a `.tap`.
5. Decodes that `.tap` back to a PRG.
6. Asserts the recovered PRG is **byte-identical** to the original **and** still a structurally valid, runnable BASIC program (line links / numbers / null-terminated).

This is meaningful because step 4 re-quantises pulse timings from zero-crossings; the test proves `wav2tapsp` preserves timing well enough that a threshold-based loader recovers the exact program.

## Changes

- **`c64tape.py`** — self-contained C64 cassette toolkit (BASIC PRG gen/validate, PRG↔TAP encode/decode, TAP→WAV synthesis). Useful on its own for making test tapes.
- **`tests/`** — `test_format.py` (codec unit tests) and `test_roundtrip.py` (in-process + real-CLI round trips, plus a constant-tone recovery check).
- **`.github/workflows/ci.yml`** — pytest across Python 3.10–3.13.
- **`wav2tapsp.py`** — refactored into importable functions (`wav_to_pulses` / `pulses_to_tap` / `wav_to_tap` / `main`) with identical CLI behaviour. Numerical pipeline unchanged except: fixed a deprecated pandas `fillna(method='ffill')` → `.ffill()`, and added the missing `type=int` to `--cpufreq` (previously `--cpufreq N` on the CLI would crash).
- `requirements-dev.txt`, `conftest.py`, README testing section + CI badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)