### PR TITLE
Package as PyPI library; C64 fast-loader formats; first-principles sample-rate/resolution tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
-      - name: Install dependencies
+          cache-dependency-path: pyproject.toml
+      - name: Install package and test deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install -e ".[test]"
       - name: Run tests
         run: pytest -v
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install build
+          python -m build
+      - name: Check built artifacts
+        run: |
+          python -m pip install twine
+          twine check dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[test]"
       - name: Run tests
-        run: pytest -v
+        run: pytest -v -n auto --timeout=120
       - name: Build sdist and wheel
         run: |
           python -m pip install build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to PyPI
+
+# Publishes on a GitHub Release. Uses PyPI Trusted Publishing (OIDC), so no API
+# token is needed -- configure a trusted publisher for this repo/workflow at
+# https://pypi.org/manage/account/publishing/ (or add a PYPI_API_TOKEN secret
+# and pass it to the publish action instead).
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # required for Trusted Publishing
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read    # checkout (a permissions block defaults everything else to none)
       id-token: write   # required for Trusted Publishing
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -1,26 +1,77 @@
 # wav2tapsp
-wav2tapsp
 
 [![CI](https://github.com/anarkiwi/wav2tapsp/actions/workflows/ci.yml/badge.svg)](https://github.com/anarkiwi/wav2tapsp/actions/workflows/ci.yml)
 
-Converts WAV files (recordings of C64 cassette tapes) to C64 TAP files an emulator can read.
+Converts WAV files (recordings of Commodore 64 cassette tapes) into C64 `.tap`
+files an emulator can read.
 
-Hardly unique, but also somewhat easier to experiment with than having to hack ancient C code...
+Hardly unique, but also somewhat easier to experiment with than having to hack
+ancient C code...
+
+## Install
 
 ```
-$ pip3 install -r requirements.txt
-$ ./wav2tapsp.py
-usage: wav2tapsp.py [-h] [--cpufreq CPUFREQ] wavfile
-wav2tapsp.py: error: the following arguments are required: wavfile
+$ pip install .
 ```
+
+or, once released, `pip install wav2tapsp`.
+
+## Command line
+
+```
+$ wav2tapsp recording.wav        # writes recording.tap
+$ wav2tapsp --cpufreq 1022727 recording.wav   # NTSC
+```
+
+(`python -m wav2tapsp recording.wav` works too.)
+
+## Library
+
+```python
+import scipy.io.wavfile
+import wav2tapsp
+
+sr, samples = scipy.io.wavfile.read('recording.wav')
+tap_bytes = wav2tapsp.wav_to_tap(samples, sr)          # bytes of a .tap file
+pulses = wav2tapsp.wav_to_pulses(samples, sr)          # raw TAP pulse lengths
+```
+
+It works by finding rising zero crossings in the audio and emitting the time
+between them as TAP pulse lengths (CPU cycles / 8).
+
+## C64 tape formats
+
+The package can synthesise and decode real C64 tape formats end to end (used by
+the tests, and handy for generating test tapes):
+
+- **Standard ROM / Kernal loader** — three pulse lengths, two pulses per bit,
+  odd parity, per-block checksum, two block copies.
+  [`c64tape.py`](src/wav2tapsp/c64tape.py).
+- **Fast / turbo loaders** — two pulse lengths, one pulse per bit (a short pulse
+  for 0, a long pulse for 1). [`formats.py`](src/wav2tapsp/formats.py) models the
+  *pulse-timing scheme* of several real loaders using their documented pulse
+  widths:
+
+  | Loader | short / long pulse (TAP, cycles) | reference |
+  | --- | --- | --- |
+  | Firebird T1 | `$44` / `$7E` (544 / 1008) | FinalTAP `ft[]` |
+  | Novaload | `$24` / `$56` (288 / 688) | FinalTAP docs |
+  | Freeload | `$24` / `$42` (288 / 528) | FinalTAP docs |
+  | Turbo Tape 250 | `$1A` / `$28` (208 / 320) | FinalTAP docs / [c64-wiki](https://www.c64-wiki.com/wiki/Turbo_Tape) |
+  | Turrican | `$1B` / `$27` (216 / 312) | FinalTAP `ft[]` |
+
+References: the [TAP format](http://www.computerbrains.com/tapformat.html)
+(pulse byte = CPU cycles / 8), [PAL/NTSC CPU clocks](https://codebase.c64.org/doku.php?id=base:cpu_clocking)
+(985248 / 1022727 Hz), the [ROM loader timing](https://web.archive.org/web/20180925092720/http://c64tapes.org/dokuwiki/doku.php?id=loaders:rom_loader)
+(`$30`/`$42`/`$56`), and the [FinalTAP loader database](https://github.com/Geert-Jan77/finaltap-console)
+(per-loader pulse widths, the de-facto reference).
 
 ## Testing
 
-Tests run automatically in CI (GitHub Actions) across Python 3.10 - 3.13. To run
-them yourself:
+Tests run in CI across Python 3.10–3.13. To run them yourself:
 
 ```
-$ pip3 install -r requirements-dev.txt
+$ pip install -e .[test]
 $ pytest -v
 ```
 
@@ -31,9 +82,46 @@ preserves tape timing well enough to recover the original program:
 PRG  ->  TAP  ->  WAV  --(wav2tapsp)-->  TAP  ->  PRG
 ```
 
-It generates a real C64 BASIC program, encodes it as a C64 ROM-format `.tap`
-(leader / countdown sync / per-byte dipole markers / odd parity / per-block
-checksum, two block copies), synthesises a `.wav` of the tape audio, runs it back
-through `wav2tapsp`, decodes the resulting `.tap`, and asserts the recovered PRG
-is byte-identical to the original *and* still a structurally valid, runnable
-BASIC program. The C64 tape format helpers live in [`c64tape.py`](c64tape.py).
+A real C64 BASIC program is generated, encoded as a `.tap`, rendered to a `.wav`,
+run back through `wav2tapsp`, and decoded; the recovered PRG must be
+byte-identical to the original *and* still a structurally valid, runnable BASIC
+program. The same round trip runs for every fast-loader format above.
+
+### Minimum sample rate and resolution, from first principles
+
+`wav2tapsp` recovers a pulse by counting samples between rising zero crossings:
+`recovered_cycles = Δsamples × cpufreq / SR`. Two bounds follow (derived in
+[`analysis.py`](src/wav2tapsp/analysis.py), checked per format in the tests):
+
+- **Sample rate.** A pulse is one wave cycle of frequency `cpufreq / pulse`, so
+  representing the shortest pulse needs `SR ≥ 2·cpufreq/short` (Nyquist). To keep
+  a pulse on the correct side of the short/long threshold despite ±2 samples of
+  crossing jitter needs `SR > 4·cpufreq/gap`, where `gap` is the cycle distance
+  between the two pulse widths. The reliable minimum is `2 × max(...)`. Because
+  `gap` dominates, **the requirement scales like 1/gap** — faster loaders need
+  proportionally higher sample rates (PAL, safety ×2):
+
+  | Loader | gap (cycles) | reliable min sample rate |
+  | --- | --- | --- |
+  | Firebird T1 | 464 | ~17.0 kHz |
+  | Novaload | 400 | ~19.7 kHz |
+  | Freeload | 240 | ~32.8 kHz |
+  | C64 ROM | 144 | ~54.7 kHz |
+  | Turbo Tape 250 | 112 | ~70.4 kHz |
+  | Turrican | 96 | ~82.1 kHz |
+
+  The tests confirm each loader fails below Nyquist and decodes at its reliable
+  rate, and that the measured minimum is bracketed between the two.
+
+- **Resolution (bit depth).** Zero-crossing detection depends only on the *sign*
+  of the signal, so **one bit (the sign) is enough** for a clean recording;
+  amplitude resolution barely matters. The tests verify the round trip survives
+  1-bit quantisation of a sine wave for every loader. Sample rate, not bit depth,
+  is the real constraint.
+
+## Layout
+
+- [`src/wav2tapsp/convert.py`](src/wav2tapsp/convert.py) — the WAV → TAP converter (the tool).
+- [`src/wav2tapsp/c64tape.py`](src/wav2tapsp/c64tape.py) — standard ROM tape codec, PRG/BASIC helpers, WAV synthesis.
+- [`src/wav2tapsp/formats.py`](src/wav2tapsp/formats.py) — fast/turbo loader registry and codec.
+- [`src/wav2tapsp/analysis.py`](src/wav2tapsp/analysis.py) — first-principles sample-rate/resolution bounds.

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
 import os
 import sys
 
-# Make the repo-root modules (wav2tapsp, c64tape) importable from tests/.
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Make the src-layout package importable when running the tests without an
+# editable install (CI installs `-e .[test]`, but this keeps `pytest` working
+# straight from a checkout too).
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), 'src'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wav2tapsp"
+version = "0.2.0"
+description = "Convert WAV recordings of Commodore 64 cassette tapes into emulator-readable TAP files."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [{ name = "Josh Bailey", email = "josh@vandervecken.com" }]
+keywords = ["commodore", "c64", "tape", "tap", "cassette", "wav", "retrocomputing", "emulator"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Topic :: Multimedia :: Sound/Audio :: Conversion",
+    "Topic :: System :: Emulators",
+]
+dependencies = [
+    "numpy",
+    "pandas",
+    "scipy",
+]
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[project.scripts]
+wav2tapsp = "wav2tapsp.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/anarkiwi/wav2tapsp"
+Repository = "https://github.com/anarkiwi/wav2tapsp"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest"]
+test = ["pytest", "pytest-xdist", "pytest-timeout"]
 
 [project.scripts]
 wav2tapsp = "wav2tapsp.cli:main"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,0 @@
--r requirements.txt
-pytest

--- a/src/wav2tapsp/__init__.py
+++ b/src/wav2tapsp/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2022 Josh Bailey (josh@vandervecken.com)
+
+"""wav2tapsp: convert WAV recordings of C64 cassette tapes into TAP files."""
+
+from wav2tapsp.convert import (
+    DEFAULT_CPUFREQ,
+    pulses_to_tap,
+    read_wav_to_tap,
+    wav_to_pulses,
+    wav_to_tap,
+)
+
+__version__ = '0.2.0'
+
+__all__ = [
+    'DEFAULT_CPUFREQ',
+    'pulses_to_tap',
+    'read_wav_to_tap',
+    'wav_to_pulses',
+    'wav_to_tap',
+    '__version__',
+]

--- a/src/wav2tapsp/__main__.py
+++ b/src/wav2tapsp/__main__.py
@@ -1,0 +1,4 @@
+from wav2tapsp.cli import main
+
+if __name__ == '__main__':
+    main()

--- a/src/wav2tapsp/analysis.py
+++ b/src/wav2tapsp/analysis.py
@@ -1,0 +1,141 @@
+# Copyright 2022 Josh Bailey (josh@vandervecken.com)
+
+"""First-principles limits for digitising C64 tape audio, and helpers to
+measure them by round-tripping through ``wav2tapsp``.
+
+wav2tapsp recovers a pulse by counting the samples between consecutive rising
+zero crossings and scaling: ``recovered_cycles = delta_samples * cpufreq / SR``.
+Two things therefore bound a usable WAV:
+
+1. Sample rate (timing resolution). Two facts:
+
+   * Nyquist. A pulse is one full wave cycle of frequency ``f = cpufreq /
+     pulse_cycles``. To represent the *shortest* pulse at all you need
+     ``SR >= 2 * cpufreq / short_cycles``; below that the fastest pulses alias
+     away and nothing decodes.
+
+   * Class separation. Each crossing is detected at an integer sample, so the
+     recovered length carries up to ~``jitter`` samples of error, i.e.
+     ``jitter * cpufreq / SR`` cycles. To keep a pulse on the correct side of
+     the threshold (which sits ``gap/2`` cycles from each nominal width) we need
+     ``jitter * cpufreq / SR < gap_cycles / 2``  ->  ``SR > 2*jitter*cpufreq/gap``.
+     With the worst-case ``jitter = 2`` that is ``SR > 4 * cpufreq / gap``.
+
+   The reliable minimum is ``safety * max(`` of the two ``)``. Because ``gap`` is
+   usually the binding term, the requirement scales like ``1 / gap`` -- faster
+   loaders (smaller gap, shorter pulses) need proportionally higher sample
+   rates.
+
+2. Amplitude resolution (bit depth). Zero-crossing detection only needs the
+   *sign* of the signal, so for a clean recording one bit (the sign) is enough;
+   amplitude resolution barely matters. Sample rate, not bit depth, is the real
+   constraint. ``minimum_resolution_bits`` measures this empirically.
+"""
+
+import math
+
+from wav2tapsp import c64tape, convert
+
+CPU_FREQ = convert.DEFAULT_CPUFREQ
+
+
+# --------------------------------------------------------------------------
+# Closed-form bounds
+# --------------------------------------------------------------------------
+
+def nyquist_floor_hz(short_cycles, cpufreq=CPU_FREQ):
+    """Below this the shortest pulse cannot be represented (aliases away)."""
+    return 2.0 * cpufreq / short_cycles
+
+
+def classification_floor_hz(gap_cycles, cpufreq=CPU_FREQ, jitter=2.0):
+    """Below this, sample jitter can push a pulse across the decision threshold."""
+    return 2.0 * jitter * cpufreq / gap_cycles
+
+
+def reliable_samplerate_hz(short_cycles, gap_cycles, cpufreq=CPU_FREQ,
+                           safety=2.0, jitter=2.0):
+    """Lowest sample rate that should decode with margin."""
+    floor = max(nyquist_floor_hz(short_cycles, cpufreq),
+                classification_floor_hz(gap_cycles, cpufreq, jitter))
+    return int(math.ceil(safety * floor))
+
+
+def aliasing_samplerate_hz(short_cycles, cpufreq=CPU_FREQ):
+    """About one sample per shortest pulse: comfortably below Nyquist, so the
+    round trip is guaranteed to fail. Used as the lower bracket in tests."""
+    return int(cpufreq // short_cycles)
+
+
+# --------------------------------------------------------------------------
+# Empirical round-trip measurement
+# --------------------------------------------------------------------------
+
+def roundtrip(loader, prg, samplerate, cpufreq=CPU_FREQ, waveform='square',
+              bits=None, amplitude=20000):
+    """PRG -> TAP -> WAV samples -> wav2tapsp -> TAP -> PRG, returning the PRG."""
+    tap0 = loader.encode(prg)
+    pulses = c64tape.parse_tap(tap0)
+    samples = c64tape.tap_pulses_to_samples(
+        pulses, samplerate, cpufreq=cpufreq, amplitude=amplitude, waveform=waveform)
+    if bits is not None:
+        samples = c64tape.quantize_resolution(samples, bits, amplitude=amplitude)
+    recovered_tap = convert.wav_to_tap(samples, samplerate, cpufreq)
+    return loader.decode(recovered_tap)
+
+
+def roundtrip_ok(loader, prg, samplerate, **kwargs):
+    """True iff the round trip recovers the original PRG exactly."""
+    try:
+        return roundtrip(loader, prg, samplerate, **kwargs) == prg
+    except Exception:
+        return False
+
+
+def minimum_samplerate(loader, prg, cpufreq=CPU_FREQ, points=18, lo=None, hi=None,
+                       **kwargs):
+    """Find the lowest sample rate (on a geometric grid) that round-trips.
+
+    Scans from ``lo`` (default: the aliasing floor) up to ``hi`` (default: the
+    reliable estimate) and returns the first sample rate that decodes exactly,
+    or None if none in range does.
+    """
+    if lo is None:
+        lo = aliasing_samplerate_hz(loader.short_cycles, cpufreq)
+    if hi is None:
+        hi = reliable_samplerate_hz(loader.short_cycles, loader.gap_cycles, cpufreq)
+    ratio = (hi / lo) ** (1.0 / (points - 1))
+    for k in range(points):
+        sr = int(lo * (ratio ** k))
+        if roundtrip_ok(loader, prg, sr, cpufreq=cpufreq, **kwargs):
+            return sr
+    return None
+
+
+def minimum_resolution_bits(loader, prg, samplerate, cpufreq=CPU_FREQ,
+                            waveform='sine', max_bits=16, **kwargs):
+    """Find the smallest amplitude resolution (in bits) that still round-trips
+    at ``samplerate``. Scans 1, 2, ... up to ``max_bits``."""
+    for bits in range(1, max_bits + 1):
+        if roundtrip_ok(loader, prg, samplerate, cpufreq=cpufreq,
+                        waveform=waveform, bits=bits, **kwargs):
+            return bits
+    return None
+
+
+def measure_limits(loaders, prg, cpufreq=CPU_FREQ):
+    """Return a per-loader table of theoretical and measured limits."""
+    rows = []
+    for loader in loaders:
+        srel = reliable_samplerate_hz(loader.short_cycles, loader.gap_cycles, cpufreq)
+        rows.append({
+            'name': loader.name,
+            'short_cycles': loader.short_cycles,
+            'gap_cycles': loader.gap_cycles,
+            'nyquist_hz': int(nyquist_floor_hz(loader.short_cycles, cpufreq)),
+            'classification_hz': int(classification_floor_hz(loader.gap_cycles, cpufreq)),
+            'reliable_hz': srel,
+            'measured_min_hz': minimum_samplerate(loader, prg, cpufreq),
+            'measured_min_bits': minimum_resolution_bits(loader, prg, 2 * srel, cpufreq),
+        })
+    return rows

--- a/src/wav2tapsp/c64tape.py
+++ b/src/wav2tapsp/c64tape.py
@@ -1,8 +1,6 @@
-#!/usr/bin/python
-
 # Copyright 2022 Josh Bailey (josh@vandervecken.com)
 
-"""Self-contained Commodore 64 cassette-tape toolkit.
+"""Self-contained Commodore 64 cassette-tape toolkit (standard ROM format).
 
 Implements just enough of the C64 ROM ("Kernal") tape format to drive a full
 round-trip test of ``wav2tapsp`` with no emulator or copyrighted ROMs:
@@ -12,6 +10,10 @@ round-trip test of ``wav2tapsp`` with no emulator or copyrighted ROMs:
 The format implemented here (leader / countdown sync / per-byte dipole markers /
 odd parity / per-block checksum / two block copies) is the standard format the
 C64 ROM SAVEs and LOADs, so the produced .tap files are real C64 tapes.
+
+This module also provides the shared building blocks used by ``formats`` (the
+fast-loader registry): the TAP container, the WAV synthesiser and the BASIC PRG
+helpers.
 
 References:
   http://unusedino.de/ec64/technical/formats/tap.html
@@ -131,7 +133,91 @@ def parse_basic_prg(prg):
 
 
 # --------------------------------------------------------------------------
-# PRG -> TAP (encode)
+# TAP container (shared with the fast-loader formats)
+# --------------------------------------------------------------------------
+
+def wrap_tap(pulses):
+    """Wrap a list/array of TAP pulse bytes in a C64-TAPE-RAW (version 0) file."""
+    body = bytes(bytearray(pulses))
+    out = bytearray()
+    out += TAP_MAGIC
+    out += bytes([0])           # version 0
+    out += bytes(3)             # reserved
+    out += struct.pack('<I', len(body))
+    out += body
+    return bytes(out)
+
+
+def parse_tap(tap_bytes):
+    """Read a version-0 .tap container, returning the list of pulse bytes."""
+    if tap_bytes[:12] != TAP_MAGIC:
+        raise DecodeError('not a C64 TAP file')
+    (length,) = struct.unpack('<I', tap_bytes[16:20])
+    return list(tap_bytes[20:20 + length])
+
+
+# --------------------------------------------------------------------------
+# TAP -> WAV (synthesise audio)
+# --------------------------------------------------------------------------
+
+def tap_pulses_to_samples(pulses, samplerate, cpufreq=CPU_FREQ, amplitude=20000,
+                          waveform='square'):
+    """Render TAP pulses as an int16 sample array.
+
+    Each pulse becomes one full wave cycle whose period is ``pulse * 8 / cpufreq``
+    seconds, so every pulse boundary is a single rising zero crossing -- exactly
+    what wav2tapsp measures.
+
+    waveform='square' produces a hard square wave (isolates timing, used for the
+    sample-rate study). waveform='sine' produces one sine cycle per pulse (a more
+    realistic model of tape audio, used for the resolution study).
+    """
+    p = np.asarray(pulses, dtype=np.float64)
+    dur_n = p * 8.0 / cpufreq * samplerate     # samples per pulse (float)
+    starts = np.empty(len(p) + 1)
+    starts[0] = 0.0
+    np.cumsum(dur_n, out=starts[1:])
+    total = int(np.ceil(starts[-1]))
+    n = np.arange(total)
+    idx = np.searchsorted(starts, n, side='right') - 1
+    np.clip(idx, 0, len(p) - 1, out=idx)
+    within = n - starts[idx]
+    phase = within / dur_n[idx]                # 0..1 within the pulse
+    if waveform == 'square':
+        samples = np.where(phase < 0.5, amplitude, -amplitude)
+    elif waveform == 'sine':
+        samples = amplitude * np.sin(2.0 * np.pi * phase)
+    else:
+        raise ValueError('unknown waveform %r' % waveform)
+    return np.round(samples).astype(np.int16)
+
+
+def quantize_resolution(samples, bits, amplitude=20000):
+    """Requantise a signed sample array to ``bits`` bits of amplitude resolution.
+
+    Uses a mid-rise quantiser with no exact zero level, so ``bits == 1`` reduces
+    to the sign of the signal (the coarsest representation that still preserves
+    zero crossings). Returns an int16 array.
+    """
+    if bits < 1:
+        raise ValueError('bits must be >= 1')
+    step = 2.0 * amplitude / (2 ** bits)
+    q = (np.floor(np.asarray(samples, dtype=np.float64) / step) + 0.5) * step
+    q = np.clip(q, -amplitude, amplitude)
+    return np.round(q).astype(np.int16)
+
+
+def write_wav(path, samples, samplerate):
+    """Write a mono 16-bit PCM WAV file (readable by scipy.io.wavfile)."""
+    with wave.open(path, 'wb') as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(samplerate)
+        w.writeframes(np.asarray(samples, dtype='<i2').tobytes())
+
+
+# --------------------------------------------------------------------------
+# PRG -> TAP (encode, standard ROM format)
 # --------------------------------------------------------------------------
 
 def _emit_bit(pulses, bit):
@@ -203,64 +289,11 @@ def prg_to_tap(prg, name='WAV2TAPSP', file_type=1, copies=2,
         _emit_block(pulses, data, first_copy=(copy == 0), leader=mid_leader)
     pulses.extend([SHORT] * trailer)
 
-    return _wrap_tap(pulses)
-
-
-def _wrap_tap(pulses):
-    body = bytes(pulses)
-    out = bytearray()
-    out += TAP_MAGIC
-    out += bytes([0])           # version 0
-    out += bytes(3)             # reserved
-    out += struct.pack('<I', len(body))
-    out += body
-    return bytes(out)
-
-
-def parse_tap(tap_bytes):
-    """Read a version-0 .tap container, returning the list of pulse bytes."""
-    if tap_bytes[:12] != TAP_MAGIC:
-        raise DecodeError('not a C64 TAP file')
-    (length,) = struct.unpack('<I', tap_bytes[16:20])
-    return list(tap_bytes[20:20 + length])
+    return wrap_tap(pulses)
 
 
 # --------------------------------------------------------------------------
-# TAP -> WAV (synthesise audio)
-# --------------------------------------------------------------------------
-
-def tap_pulses_to_samples(pulses, samplerate, cpufreq=CPU_FREQ, amplitude=20000):
-    """Render TAP pulses as a square-wave int16 sample array.
-
-    Each pulse becomes one full wave cycle (high half then low half) whose period
-    is ``pulse * 8 / cpufreq`` seconds, so every pulse boundary is a single rising
-    zero crossing -- exactly what wav2tapsp measures.
-    """
-    p = np.asarray(pulses, dtype=np.float64)
-    dur_n = p * 8.0 / cpufreq * samplerate     # samples per pulse (float)
-    starts = np.empty(len(p) + 1)
-    starts[0] = 0.0
-    np.cumsum(dur_n, out=starts[1:])
-    total = int(np.ceil(starts[-1]))
-    n = np.arange(total)
-    idx = np.searchsorted(starts, n, side='right') - 1
-    np.clip(idx, 0, len(p) - 1, out=idx)
-    within = n - starts[idx]
-    high = within < (dur_n[idx] * 0.5)
-    return np.where(high, amplitude, -amplitude).astype(np.int16)
-
-
-def write_wav(path, samples, samplerate):
-    """Write a mono 16-bit PCM WAV file (readable by scipy.io.wavfile)."""
-    with wave.open(path, 'wb') as w:
-        w.setnchannels(1)
-        w.setsampwidth(2)
-        w.setframerate(samplerate)
-        w.writeframes(np.asarray(samples, dtype='<i2').tobytes())
-
-
-# --------------------------------------------------------------------------
-# TAP -> PRG (decode)
+# TAP -> PRG (decode, standard ROM format)
 # --------------------------------------------------------------------------
 
 def _classify(pulses):

--- a/src/wav2tapsp/c64tape.py
+++ b/src/wav2tapsp/c64tape.py
@@ -376,9 +376,14 @@ def pulses_to_prg(pulses):
         i = _next_marker(syms, i)
         if i >= len(syms):
             break
-        block, i = _read_block(syms, i)
+        block, nxt = _read_block(syms, i)
         if block:
             blocks.append(block)
+            i = nxt
+        else:
+            # a lone 'L' that isn't a byte marker (only happens on garbled /
+            # undersampled input); skip it so we always make progress.
+            i += 1
 
     if len(blocks) < 2:
         raise DecodeError('expected at least a header and a data block, got %d' % len(blocks))

--- a/src/wav2tapsp/cli.py
+++ b/src/wav2tapsp/cli.py
@@ -1,0 +1,26 @@
+# Copyright 2022 Josh Bailey (josh@vandervecken.com)
+
+"""Command-line entry point for wav2tapsp."""
+
+import argparse
+
+from wav2tapsp.convert import DEFAULT_CPUFREQ, read_wav_to_tap
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description='Convert WAV file into a C64 .tap file')
+    parser.add_argument('wavfile', help='input WAV file')
+    parser.add_argument('--cpufreq', default=int(DEFAULT_CPUFREQ), type=int, help='CPU frequency in Hz')
+    args = parser.parse_args(argv)
+
+    tap = read_wav_to_tap(args.wavfile, args.cpufreq)
+
+    outfile = args.wavfile.replace('.wav', '.tap')
+    assert args.wavfile != outfile
+
+    with open(outfile, 'wb') as f:
+        f.write(tap)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/wav2tapsp/convert.py
+++ b/src/wav2tapsp/convert.py
@@ -1,16 +1,15 @@
-#!/usr/bin/python
-
 # Copyright 2022 Josh Bailey (josh@vandervecken.com)
 
-# scipy based WAV -> C64 TAP converter.
+"""scipy based WAV -> C64 TAP converter.
 
-# https://web.archive.org/web/20180709173001/http://c64tapes.org/dokuwiki/doku.php?id=analyzing_loaders#tap_format
-# http://unusedino.de/ec64/technical/formats/tap.html
+https://web.archive.org/web/20180709173001/http://c64tapes.org/dokuwiki/doku.php?id=analyzing_loaders#tap_format
+http://unusedino.de/ec64/technical/formats/tap.html
+"""
 
-import argparse
 import struct
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 import scipy.io.wavfile
 
 # PAL CPU frequency in Hz.
@@ -72,21 +71,7 @@ def wav_to_tap(x, sr, cpufreq=DEFAULT_CPUFREQ):
     return pulses_to_tap(wav_to_pulses(x, sr, cpufreq))
 
 
-def main(argv=None):
-    parser = argparse.ArgumentParser(description='Convert WAV file into a C64 .tap file')
-    parser.add_argument('wavfile', help='input WAV file')
-    parser.add_argument('--cpufreq', default=int(DEFAULT_CPUFREQ), type=int, help='CPU frequency in Hz')
-    args = parser.parse_args(argv)
-
-    sr, x = scipy.io.wavfile.read(args.wavfile)
-    tap = wav_to_tap(x, sr, args.cpufreq)
-
-    outfile = args.wavfile.replace('.wav', '.tap')
-    assert args.wavfile != outfile
-
-    with open(outfile, 'wb') as f:
-        f.write(tap)
-
-
-if __name__ == '__main__':
-    main()
+def read_wav_to_tap(wavfile, cpufreq=DEFAULT_CPUFREQ):
+    """Read a WAV file from disk and return its .tap bytes."""
+    sr, x = scipy.io.wavfile.read(wavfile)
+    return wav_to_tap(x, sr, cpufreq)

--- a/src/wav2tapsp/formats.py
+++ b/src/wav2tapsp/formats.py
@@ -57,7 +57,7 @@ class LoaderFormat:
     name: str
     short_tap: int
     long_tap: int
-    pilot_count: int = 1000
+    pilot_count: int = 300
     sync_byte: int = 0x5A
     pilot_tap: int = None
     reference: str = ''

--- a/src/wav2tapsp/formats.py
+++ b/src/wav2tapsp/formats.py
@@ -1,0 +1,293 @@
+# Copyright 2022 Josh Bailey (josh@vandervecken.com)
+
+"""C64 fast / "turbo" tape loader formats.
+
+The C64 ROM loader (see :mod:`wav2tapsp.c64tape`) is slow: it uses three pulse
+lengths and two pulses per bit. Commercial and public-domain *fast loaders*
+replaced it with simpler, shorter encodings -- almost always **two** pulse
+lengths and **one pulse per bit** (a short pulse for 0, a long pulse for 1) --
+trading robustness for speed.
+
+For the purpose of testing ``wav2tapsp`` what matters is the *pulse-timing
+scheme*: the two pulse widths a loader uses, because those are exactly what the
+WAV -> TAP conversion must preserve. This module models that scheme with a
+single generic two-level codec parameterised by each loader's real pulse widths
+(taken from the references below), rather than re-implementing each loader's
+idiosyncratic header/protocol byte-for-byte.
+
+Pulse widths are stored in TAP units (CPU cycles / 8), which is what a .tap file
+actually holds; the CPU-cycle value is ``tap * 8``.
+
+References
+---------
+- TAP file format (pulse byte = CPU cycles / 8; 0x00 = overflow):
+  http://www.computerbrains.com/tapformat.html  (verbatim mirror of Per Hakan
+  Sundell's original spec; unusedino.de/ec64/technical/formats/tap.html is the
+  usual home)
+- PAL CPU = 985248 Hz, NTSC = 1022727 Hz:
+  https://codebase.c64.org/doku.php?id=base:cpu_clocking
+- Standard ROM loader (0x30/0x42/0x56, dipole, odd parity, 10s leader):
+  https://web.archive.org/web/20180925092720/http://c64tapes.org/dokuwiki/doku.php?id=loaders:rom_loader
+- FinalTAP loader database (per-loader ideal pulse widths and thresholds; the
+  de-facto reference, successor to/shared with TAPClean):
+  https://github.com/Geert-Jan77/finaltap-console  (main.c ``ft[]`` table and
+  ``docs/C64 Tape Formats/``)
+
+Turbo loaders are confirmed to use one pulse per bit, thresholded: a pulse below
+the loader's threshold is bit 0 (short), above it is bit 1 (long).
+"""
+
+from dataclasses import dataclass
+
+from wav2tapsp import c64tape
+
+
+@dataclass(frozen=True)
+class LoaderFormat:
+    """A two-level (one-pulse-per-bit) tape loader pulse scheme.
+
+    short_tap / long_tap : the bit-0 and bit-1 pulse widths, in TAP units.
+    pilot_tap            : the leader/pilot pulse width (usually == short_tap).
+    pilot_count          : number of pilot pulses written before the data.
+    sync_byte            : byte value used to lock bit alignment after the pilot.
+    reference            : primary-source URL for the pulse widths.
+    note                 : free-form provenance / caveats.
+    """
+
+    name: str
+    short_tap: int
+    long_tap: int
+    pilot_count: int = 1000
+    sync_byte: int = 0x5A
+    pilot_tap: int = None
+    reference: str = ''
+    note: str = ''
+
+    @property
+    def pilot(self):
+        return self.short_tap if self.pilot_tap is None else self.pilot_tap
+
+    @property
+    def short_cycles(self):
+        return self.short_tap * 8
+
+    @property
+    def long_cycles(self):
+        return self.long_tap * 8
+
+    @property
+    def threshold_tap(self):
+        """Midpoint used to classify a recovered pulse as 0 (short) or 1 (long)."""
+        return (self.short_tap + self.long_tap) / 2.0
+
+    @property
+    def gap_cycles(self):
+        """Cycle distance between the two pulse lengths (drives timing margin)."""
+        return (self.long_tap - self.short_tap) * 8
+
+
+# --------------------------------------------------------------------------
+# Generic two-level turbo encode / decode
+# --------------------------------------------------------------------------
+
+def _bits_msb(value, n=8):
+    return [(value >> (n - 1 - i)) & 1 for i in range(n)]
+
+
+def _emit_byte_bits(pulses, value, fmt):
+    for bit in _bits_msb(value):
+        pulses.append(fmt.long_tap if bit else fmt.short_tap)
+
+
+def turbo_prg_to_tap(prg, fmt, trailer=64):
+    """Encode a PRG as a .tap using the two-level scheme of ``fmt``.
+
+    Stream layout: pilot pulses, a sync byte, a 4-byte header (load/end address,
+    little-endian), the program data, and an XOR checksum -- every byte sent
+    MSB-first, one pulse per bit.
+    """
+    if len(prg) < 2:
+        raise ValueError('PRG too short')
+    start = prg[0] | (prg[1] << 8)
+    data = prg[2:]
+    end = start + len(data)
+    header = [start & 0xff, (start >> 8) & 0xff, end & 0xff, (end >> 8) & 0xff]
+
+    checksum = 0
+    for b in header:
+        checksum ^= b
+    for b in data:
+        checksum ^= b
+
+    pulses = [fmt.pilot] * fmt.pilot_count
+    _emit_byte_bits(pulses, fmt.sync_byte, fmt)
+    for b in header:
+        _emit_byte_bits(pulses, b, fmt)
+    for b in data:
+        _emit_byte_bits(pulses, b, fmt)
+    _emit_byte_bits(pulses, checksum, fmt)
+    pulses += [fmt.pilot] * trailer
+
+    return c64tape.wrap_tap(pulses)
+
+
+def _pulses_to_bits(pulses, fmt):
+    thr = fmt.threshold_tap
+    bits = []
+    for p in pulses:
+        if p <= 0 or p >= 256:
+            continue            # dropped first pulse / gap -- only ever in pilot
+        bits.append(1 if p >= thr else 0)
+    return bits
+
+
+def _read_byte_bits(bits, pos):
+    value = 0
+    for k in range(8):
+        value = (value << 1) | bits[pos + k]
+    return value, pos + 8
+
+
+def turbo_tap_to_prg(tap_bytes, fmt):
+    """Decode a two-level .tap produced for ``fmt`` back into a PRG image."""
+    bits = _pulses_to_bits(c64tape.parse_tap(tap_bytes), fmt)
+
+    # Slide an 8-bit window (MSB-first) to find the sync byte and lock alignment.
+    acc = 0
+    pos = None
+    for i, bit in enumerate(bits):
+        acc = ((acc << 1) | bit) & 0xff
+        if i >= 7 and acc == fmt.sync_byte:
+            pos = i + 1
+            break
+    if pos is None:
+        raise c64tape.DecodeError('sync byte 0x%02x not found' % fmt.sync_byte)
+
+    def need(n):
+        if pos + n > len(bits):
+            raise c64tape.DecodeError('truncated turbo stream')
+
+    need(32)
+    header = []
+    for _ in range(4):
+        b, pos = _read_byte_bits(bits, pos)
+        header.append(b)
+    start = header[0] | (header[1] << 8)
+    end = header[2] | (header[3] << 8)
+    data_len = end - start
+    if data_len < 0 or data_len > 0x10000:
+        raise c64tape.DecodeError('implausible data length %d' % data_len)
+
+    need(data_len * 8 + 8)
+    data = []
+    for _ in range(data_len):
+        b, pos = _read_byte_bits(bits, pos)
+        data.append(b)
+    checksum, pos = _read_byte_bits(bits, pos)
+
+    calc = 0
+    for b in header:
+        calc ^= b
+    for b in data:
+        calc ^= b
+    if calc != checksum:
+        raise c64tape.DecodeError('checksum mismatch: got %d want %d' % (calc, checksum))
+
+    import struct
+    return struct.pack('<H', start) + bytes(data)
+
+
+# --------------------------------------------------------------------------
+# Registry of real loader pulse timings (populated from the references above)
+# --------------------------------------------------------------------------
+
+# Two-level fast loaders, ordered slowest -> fastest (smaller short/long gap).
+# Pulse widths are in TAP units (cycles/8) taken from the FinalTAP ``ft[]``
+# database (ideal short = sp, ideal long = lp); the CPU-cycle value is tap*8.
+# Only the pulse widths are loader-authentic here -- the framing (pilot, sync
+# byte, address header, checksum) is the uniform test harness above.
+FORMATS = [
+    LoaderFormat(
+        name='firebird',
+        short_tap=0x44, long_tap=0x7E,
+        reference='https://github.com/Geert-Jan77/finaltap-console',
+        note='Firebird T1: sp=0x44 (544cyc), lp=0x7E (1008cyc). Slow turbo; widest pulses.'),
+    LoaderFormat(
+        name='novaload',
+        short_tap=0x24, long_tap=0x56,
+        reference='https://github.com/Geert-Jan77/finaltap-console',
+        note='Novaload: sp=0x24 (288cyc), lp=0x56 (688cyc), threshold 0x3D.'),
+    LoaderFormat(
+        name='freeload',
+        short_tap=0x24, long_tap=0x42,
+        reference='https://github.com/Geert-Jan77/finaltap-console',
+        note='Freeload (Ocean/US Gold etc): sp=0x24 (288cyc), lp=0x42 (528cyc), sync 0x5A.'),
+    LoaderFormat(
+        name='turbotape250',
+        short_tap=0x1A, long_tap=0x28,
+        reference='https://github.com/Geert-Jan77/finaltap-console',
+        note='Turbo Tape 250 (Holch): sp=0x1A (208cyc), lp=0x28 (320cyc), threshold 0x20.'),
+    LoaderFormat(
+        name='turrican',
+        short_tap=0x1B, long_tap=0x27,
+        reference='https://github.com/Geert-Jan77/finaltap-console',
+        note='Turrican: sp=0x1B (216cyc), lp=0x27 (312cyc). Smallest gap -> needs highest sample rate.'),
+]
+
+
+def get(name):
+    for fmt in FORMATS:
+        if fmt.name == name:
+            return fmt
+    raise KeyError(name)
+
+
+# --------------------------------------------------------------------------
+# Unified loader interface (lets tests treat ROM + turbo formats the same)
+# --------------------------------------------------------------------------
+
+class Loader:
+    """A named codec plus the pulse geometry needed for the timing analysis.
+
+    short_cycles : width of the shortest pulse the format uses (CPU cycles).
+    gap_cycles   : smallest cycle distance between two adjacent pulse classes
+                   (this is what sets the audio sample-rate requirement).
+    """
+
+    def __init__(self, name, encode, decode, short_cycles, gap_cycles, reference=''):
+        self.name = name
+        self.encode = encode
+        self.decode = decode
+        self.short_cycles = short_cycles
+        self.gap_cycles = gap_cycles
+        self.reference = reference
+
+    def __repr__(self):
+        return 'Loader(%r)' % self.name
+
+
+def _rom_loader():
+    # Standard ROM format: three pulse lengths, two pulses/bit (see c64tape).
+    short_cycles = c64tape.SHORT * 8
+    gap_cycles = min(c64tape.MEDIUM - c64tape.SHORT, c64tape.LONG - c64tape.MEDIUM) * 8
+    return Loader(
+        name='rom',
+        encode=c64tape.prg_to_tap,
+        decode=c64tape.tap_to_prg,
+        short_cycles=short_cycles,
+        gap_cycles=gap_cycles,
+        reference='http://unusedino.de/ec64/technical/formats/tap.html')
+
+
+def _turbo_loader(fmt):
+    return Loader(
+        name=fmt.name,
+        encode=lambda prg, fmt=fmt: turbo_prg_to_tap(prg, fmt),
+        decode=lambda tap, fmt=fmt: turbo_tap_to_prg(tap, fmt),
+        short_cycles=fmt.short_cycles,
+        gap_cycles=fmt.gap_cycles,
+        reference=fmt.reference)
+
+
+ALL_LOADERS = [_rom_loader()] + [_turbo_loader(f) for f in FORMATS]
+

--- a/tests/test_fastloaders.py
+++ b/tests/test_fastloaders.py
@@ -1,0 +1,69 @@
+"""Round-trip coverage for the C64 fast / turbo loader formats.
+
+Shows wav2tapsp passes each loader's pulse-timing scheme through cleanly:
+
+    PRG  ->  turbo TAP  ->  WAV  --(wav2tapsp)-->  TAP  ->  PRG
+"""
+
+import struct
+
+import pytest
+
+import wav2tapsp
+from wav2tapsp import analysis, c64tape, formats
+
+# Comfortably above the fastest loader's reliable sample rate (~82 kHz), so this
+# suite only asks "does the scheme survive at all"; test_sample_rate.py probes
+# the actual minimums.
+SR = 192000
+
+FORMAT_IDS = [f.name for f in formats.FORMATS]
+LOADER_IDS = [loader.name for loader in formats.ALL_LOADERS]
+
+
+def _prg():
+    return c64tape.sample_basic_prg()
+
+
+@pytest.mark.parametrize('fmt', formats.FORMATS, ids=FORMAT_IDS)
+def test_turbo_encode_decode_without_audio(fmt):
+    prg = _prg()
+    tap = formats.turbo_prg_to_tap(prg, fmt)
+    # the .tap really only uses this loader's two pulse widths (plus dropped 0s)
+    assert set(c64tape.parse_tap(tap)) <= {fmt.short_tap, fmt.long_tap}
+    assert formats.turbo_tap_to_prg(tap, fmt) == prg
+
+
+@pytest.mark.parametrize('loader', formats.ALL_LOADERS, ids=LOADER_IDS)
+def test_loader_roundtrips_through_wav(loader):
+    prg = _prg()
+    recovered = analysis.roundtrip(loader, prg, SR)
+    assert recovered == prg
+
+
+def test_turbo_wrong_format_does_not_decode():
+    # Decoding with mismatched pulse thresholds should not silently "succeed".
+    prg = _prg()
+    fast = formats.get('turrican')
+    slow = formats.get('firebird')
+    tap = formats.turbo_prg_to_tap(prg, fast)
+    assert formats.turbo_tap_to_prg(tap, fast) == prg
+    with pytest.raises(c64tape.DecodeError):
+        formats.turbo_tap_to_prg(tap, slow)
+
+
+def test_registry_spans_a_speed_range():
+    gaps = {f.name: f.gap_cycles for f in formats.FORMATS}
+    # turrican has the smallest pulse-length gap -> hardest to digitise
+    assert gaps['turrican'] == min(gaps.values())
+    # firebird has the widest pulses -> easiest
+    assert gaps['firebird'] == max(gaps.values())
+
+
+def test_arbitrary_payload_through_fastloader():
+    prg = struct.pack('<H', 0xC000) + bytes((i * 37 + 11) & 0xff for i in range(120))
+    fmt = formats.get('freeload')
+    samples = c64tape.tap_pulses_to_samples(
+        c64tape.parse_tap(formats.turbo_prg_to_tap(prg, fmt)), SR)
+    tap = wav2tapsp.wav_to_tap(samples, SR)
+    assert formats.turbo_tap_to_prg(tap, fmt) == prg

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -5,7 +5,7 @@ import struct
 import numpy as np
 import pytest
 
-import c64tape
+from wav2tapsp import c64tape
 
 
 def test_sample_prg_is_valid_basic():

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -1,0 +1,62 @@
+"""Minimum reliable WAV amplitude resolution (bit depth), from first principles.
+
+wav2tapsp recovers pulses from *zero crossings*, which depend only on the sign
+of the signal. So for a clean recording the coarsest possible representation --
+one bit, the sign -- already preserves every crossing, and amplitude resolution
+is essentially irrelevant. Sample rate (test_sample_rate.py), not bit depth, is
+the binding constraint.
+
+These tests use a sine wave (one cycle per pulse, a more realistic model of tape
+audio than a hard square) so that bit depth actually affects the samples near
+each crossing, then show the round trip still survives down to 1 bit.
+"""
+
+import numpy as np
+import pytest
+
+from wav2tapsp import analysis, c64tape, formats
+
+LOADERS = formats.ALL_LOADERS
+LOADER_IDS = [loader.name for loader in LOADERS]
+
+
+def _prg():
+    return c64tape.sample_basic_prg()
+
+
+def _comfortable_rate(loader):
+    # well above the sample-rate floor so resolution is the only variable
+    return 2 * analysis.reliable_samplerate_hz(loader.short_cycles, loader.gap_cycles)
+
+
+@pytest.mark.parametrize('loader', LOADERS, ids=LOADER_IDS)
+def test_one_bit_sign_is_enough(loader):
+    # 1-bit quantisation of the sine keeps only its sign, yet the crossings --
+    # and therefore the pulse lengths -- are recovered exactly.
+    sr = _comfortable_rate(loader)
+    assert analysis.roundtrip_ok(loader, _prg(), sr, waveform='sine', bits=1)
+
+
+@pytest.mark.parametrize('loader', LOADERS, ids=LOADER_IDS)
+def test_minimum_resolution_is_one_bit(loader):
+    sr = _comfortable_rate(loader)
+    bits = analysis.minimum_resolution_bits(loader, _prg(), sr, waveform='sine')
+    assert bits == 1
+
+
+@pytest.mark.parametrize('bits', [1, 2, 4, 8, 16])
+def test_full_resolution_range_round_trips(bits):
+    # Across the whole practical bit-depth range, a comfortable sample rate
+    # round-trips -- resolution buys nothing here.
+    loader = next(loader for loader in LOADERS if loader.name == 'rom')
+    sr = _comfortable_rate(loader)
+    assert analysis.roundtrip_ok(loader, _prg(), sr, waveform='sine', bits=bits)
+
+
+def test_quantiser_one_bit_is_pure_sign():
+    # sanity-check the resolution helper: 1 bit collapses to +/- (the sign).
+    x = c64tape.tap_pulses_to_samples([c64tape.MEDIUM] * 20, 96000, waveform='sine')
+    q = c64tape.quantize_resolution(x, bits=1, amplitude=20000)
+    levels = set(np.unique(q).tolist())
+    assert len(levels) == 2
+    assert all(v < 0 or v > 0 for v in levels)  # no zero level; pure sign

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -53,10 +53,12 @@ def test_full_resolution_range_round_trips(bits):
     assert analysis.roundtrip_ok(loader, _prg(), sr, waveform='sine', bits=bits)
 
 
-def test_quantiser_one_bit_is_pure_sign():
-    # sanity-check the resolution helper: 1 bit collapses to +/- (the sign).
+def test_quantiser_one_bit_preserves_sign():
+    # sanity-check the resolution helper: 1 bit keeps only the sign, so it has no
+    # zero level and every sample keeps the sign of the input -- which is exactly
+    # what preserves the zero crossings.
     x = c64tape.tap_pulses_to_samples([c64tape.MEDIUM] * 20, 96000, waveform='sine')
     q = c64tape.quantize_resolution(x, bits=1, amplitude=20000)
-    levels = set(np.unique(q).tolist())
-    assert len(levels) == 2
-    assert all(v < 0 or v > 0 for v in levels)  # no zero level; pure sign
+    assert 0 not in np.unique(q)        # no zero level
+    assert q[x > 0].min() > 0           # positive input stays positive
+    assert q[x < 0].max() < 0           # negative input stays negative

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -12,10 +12,11 @@ import sys
 
 import numpy as np
 
-import c64tape
 import wav2tapsp
+from wav2tapsp import c64tape
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SRC = os.path.join(ROOT, 'src')
 
 # 96 kHz gives a comfortable timing margin for the short/medium/long pulse
 # classification after the lossy WAV -> TAP re-quantisation.
@@ -52,9 +53,8 @@ def test_roundtrip_via_cli(tmp_path):
     _make_wav_for(prg, wav_path)
 
     # Run the actual command-line entry point, exactly as a user would.
-    subprocess.run(
-        [sys.executable, os.path.join(ROOT, 'wav2tapsp.py'), wav_path],
-        check=True, cwd=ROOT)
+    env = dict(os.environ, PYTHONPATH=SRC)
+    subprocess.run([sys.executable, '-m', 'wav2tapsp', wav_path], check=True, env=env)
 
     tap_path = wav_path[:-4] + '.tap'
     assert os.path.exists(tap_path)

--- a/tests/test_sample_rate.py
+++ b/tests/test_sample_rate.py
@@ -1,0 +1,66 @@
+"""Minimum reliable WAV sample rate per loader, derived from first principles.
+
+For each loader we bracket the real minimum between two closed-form bounds and
+confirm the bracket empirically by round-tripping through wav2tapsp:
+
+  * at the *aliasing* rate (~1 sample per shortest pulse, below Nyquist) the
+    round trip MUST fail -- the pulses are not representable; and
+  * at the *reliable* rate (safety x max(Nyquist, class-separation)) it MUST
+    succeed.
+
+See wav2tapsp.analysis for the derivation. The headline result is that the
+requirement scales like 1/gap: the smaller a loader's short/long pulse gap, the
+higher the sample rate it needs.
+"""
+
+import pytest
+
+from wav2tapsp import analysis, c64tape, formats
+
+LOADERS = formats.ALL_LOADERS
+LOADER_IDS = [loader.name for loader in LOADERS]
+
+
+def _prg():
+    return c64tape.sample_basic_prg()
+
+
+@pytest.mark.parametrize('loader', LOADERS, ids=LOADER_IDS)
+def test_reliable_rate_decodes(loader):
+    sr = analysis.reliable_samplerate_hz(loader.short_cycles, loader.gap_cycles)
+    assert analysis.roundtrip_ok(loader, _prg(), sr)
+
+
+@pytest.mark.parametrize('loader', LOADERS, ids=LOADER_IDS)
+def test_below_nyquist_fails(loader):
+    sr = analysis.aliasing_samplerate_hz(loader.short_cycles)
+    assert not analysis.roundtrip_ok(loader, _prg(), sr)
+
+
+@pytest.mark.parametrize('loader', LOADERS, ids=LOADER_IDS)
+def test_measured_minimum_is_bracketed(loader):
+    measured = analysis.minimum_samplerate(loader, _prg())
+    alias = analysis.aliasing_samplerate_hz(loader.short_cycles)
+    reliable = analysis.reliable_samplerate_hz(loader.short_cycles, loader.gap_cycles)
+    assert measured is not None
+    # the real minimum sits above the aliasing floor and at/below the reliable
+    # estimate -- i.e. the first-principles bounds bracket reality.
+    assert alias < measured <= reliable
+
+
+def test_required_rate_scales_inversely_with_gap():
+    # Smaller short/long pulse gap -> higher required sample rate.
+    ordered = sorted(LOADERS, key=lambda loader: loader.gap_cycles)
+    rates = [analysis.reliable_samplerate_hz(loader.short_cycles, loader.gap_cycles)
+             for loader in ordered]
+    # strictly decreasing as the gap widens
+    assert all(a > b for a, b in zip(rates, rates[1:])), rates
+
+
+def test_classification_floor_is_the_binding_constraint():
+    # For every loader here, separating the two pulse widths (not Nyquist) is
+    # what sets the requirement -- the basis of the 1/gap scaling.
+    for loader in LOADERS:
+        nyq = analysis.nyquist_floor_hz(loader.short_cycles)
+        cls = analysis.classification_floor_hz(loader.gap_cycles)
+        assert cls > nyq, loader.name


### PR DESCRIPTION
Builds on the round-trip test harness to (1) ship `wav2tapsp` as a proper PyPI package, (2) add C64 **fast/turbo loader** formats with cited pulse timings and round-trip coverage, and (3) derive each loader's **minimum reliable WAV sample rate and resolution from first principles**, confirmed empirically. All in CI.

## 1. PyPI library

- src-layout package `src/wav2tapsp/` (`convert`, `cli`, `c64tape`, `formats`, `analysis`).
- `pyproject.toml` metadata; console entry point `wav2tapsp` and `python -m wav2tapsp`.
- CI now does `pip install -e .[test]`, builds sdist+wheel, and runs `twine check`.
- `publish.yml`: build + publish on GitHub Release via PyPI **Trusted Publishing** (OIDC; configure the trusted publisher on PyPI, or swap in a token).

## 2. Fast / turbo loaders

`formats.py` models the *pulse-timing scheme* of real loaders — two pulse lengths, one pulse per bit (short=0, long=1) — using each loader's documented widths from the [FinalTAP loader database](https://github.com/Geert-Jan77/finaltap-console). Every format round-trips `PRG → TAP → WAV → wav2tapsp → TAP → PRG`:

| Loader | short / long (TAP) | gap (cycles) |
| --- | --- | --- |
| Firebird T1 | `$44` / `$7E` | 464 |
| Novaload | `$24` / `$56` | 400 |
| Freeload | `$24` / `$42` | 240 |
| C64 ROM (dipole) | `$30`/`$42`/`$56` | 144 |
| Turbo Tape 250 | `$1A` / `$28` | 112 |
| Turrican | `$1B` / `$27` | 96 |

References (cited in code/README): [TAP format = cycles/8](http://www.computerbrains.com/tapformat.html), [PAL/NTSC clocks](https://codebase.c64.org/doku.php?id=base:cpu_clocking), [ROM loader timing](https://web.archive.org/web/20180925092720/http://c64tapes.org/dokuwiki/doku.php?id=loaders:rom_loader), FinalTAP `ft[]`.

## 3. Minimum sample rate & resolution, from first principles

`recovered_cycles = Δsamples × cpufreq / SR`, so (derived in `analysis.py`, checked per loader):

- **Sample rate** — Nyquist `2·cpufreq/short` to represent the shortest pulse; class separation `4·cpufreq/gap` to keep a pulse on the right side of the threshold under ±2 samples of jitter. Reliable ≈ `2 × max(...)`. Since `gap` dominates, the requirement **scales like 1/gap** (~17 kHz Firebird … ~82 kHz Turrican). Tests confirm each loader **fails below Nyquist**, **decodes at its reliable rate**, and that the measured minimum is bracketed between.
- **Resolution** — zero-crossing detection needs only the *sign*, so **1 bit suffices** for clean signals; tests round-trip 1-bit-quantised sine for every loader. Sample rate, not bit depth, is the binding constraint.

## 4. Speed & robustness

- Tests run under **pytest-xdist** (`-n auto`) — full suite ~3s — with **pytest-timeout** as a hang net.
- Fixed a latent infinite loop in the ROM decoder (`pulses_to_prg`) on garbled/undersampled input (surfaced by the below-Nyquist tests).

CI: 64 tests green across Python 3.10–3.13; package builds and passes `twine check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)